### PR TITLE
add Reactions container for reaction IO ops

### DIFF
--- a/.scalafmt
+++ b/.scalafmt
@@ -1,0 +1,3 @@
+--style defaultWithAlign
+--alignByArrowEnumeratorGenerator true
+--maxColumn 140

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+## [Unreleased]
+
+### Changed
+
+- #7 `Map[String, ...]` replaced by `Reactions` container for IO ops
+    
+## [0.1.0] 2016-08-30
+
+### Added
+
+- Implemented all models and methods available for the Telegram Bot API:
+  
+    - [Available types](https://core.telegram.org/bots/api#available-types)
+    - [Available methods](https://core.telegram.org/bots/api#available-methods)
+    - [Updating messages](https://core.telegram.org/bots/api#updating-messages)
+    - [Inline mode](https://core.telegram.org/bots/api#inline-mode)
+  
+    However, this version does not support webhooks and sending payload other than JSON.

--- a/README.md
+++ b/README.md
@@ -90,18 +90,11 @@ for `instance.run(...)` with all three components described above.
 object NaiveBot extends Telepooz with App {
 
   implicit val are = new ApiRequestExecutor {}
-  val poller  = new Polling
-  val reactor = new Reactor {
-
-    /** Initialize as lazy val */
-    lazy val reactions: Map[String, Reaction] = Map(
-      "/start" → (implicit message ⇒ args ⇒ {
-        reply("You are started!")
-      }),
-      "/test" → (implicit message ⇒ args ⇒ {
-        reply("Hi there!")
-      })
-    )
+  val poller       = new Polling
+  val reactor      = new Reactor {
+    val reactions = Reactions()
+      .on("/start")(implicit message ⇒ args ⇒ reply("You are started!"))
+      .on("/test")(implicit message ⇒ args ⇒ reply("Hi there!"))
   }
 
   instance.run((are, poller, reactor))

--- a/src/main/scala/com/github/nikdon/telepooz/Produce.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/Produce.scala
@@ -1,5 +1,6 @@
 package com.github.nikdon.telepooz
 
+
 trait Produce[A, B] {
   def produce(a: A): B
 }

--- a/src/main/scala/com/github/nikdon/telepooz/engine/ApiRequestExecutor.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/ApiRequestExecutor.scala
@@ -19,14 +19,14 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 
 
 abstract class ApiRequestExecutor(implicit system: ActorSystem, materializer: Materializer, ec: ExecutionContextExecutor)
-  extends (RawRequest ~> Future)
-          with CirceSupport
-          with CirceEncoders
-          with CirceDecoders {
+    extends (RawRequest ~> Future)
+    with CirceSupport
+    with CirceEncoders
+    with CirceDecoders {
 
-  protected lazy val config      : Config = ConfigFactory.load()
+  protected lazy val config: Config       = ConfigFactory.load()
   protected lazy val telegramHost: String = config.getString("telegram.host")
-  protected lazy val token       : String = config.getString("telegram.token")
+  protected lazy val token: String        = config.getString("telegram.token")
 
   private[this] lazy val http = Http()
 
@@ -39,7 +39,7 @@ abstract class ApiRequestExecutor(implicit system: ActorSystem, materializer: Ma
     val uri = "https://" |+| telegramHost |+| "/bot" + token |+| "/" + methodName
     for {
       response ← http.singleRequest(RequestBuilding.Post(Uri(uri), content = dropNulls(payload)))
-      decoded ← circeUnmarshaller(responseDecoder).apply(response.entity)
+      decoded  ← circeUnmarshaller(responseDecoder).apply(response.entity)
     } yield decoded
   }
 

--- a/src/main/scala/com/github/nikdon/telepooz/engine/MockApiRequestExecutor.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/MockApiRequestExecutor.scala
@@ -14,76 +14,77 @@ import scala.util.Random
 
 
 class MockApiRequestExecutor(nUpdates: Int = 1)(implicit system: ActorSystem, materializer: Materializer, ec: ExecutionContextExecutor)
-  extends ApiRequestExecutor()(system, materializer, ec) with tags.Syntax {
+    extends ApiRequestExecutor()(system, materializer, ec)
+    with tags.Syntax {
 
   def r = Random
 
-  val fakeChat = Chat(r.nextLong.chatId, ChatType.Private)
-  val fakeFile = File(r.nextString(5).fileId, None, None)
-  val fakeMessage = Message(r.nextLong.messageId, new Date(r.nextLong), Chat(r.nextLong.chatId, ChatType.Private))
+  val fakeChat              = Chat(r.nextLong.chatId, ChatType.Private)
+  val fakeFile              = File(r.nextString(5).fileId, None, None)
+  val fakeMessage           = Message(r.nextLong.messageId, new Date(r.nextLong), Chat(r.nextLong.chatId, ChatType.Private))
   val fakeUserProfilePhotos = UserProfilePhotos(r.nextInt, Vector.empty)
-  val fakeUser = User(r.nextInt.userId, r.nextString(3))
+  val fakeUser              = User(r.nextInt.userId, r.nextString(3))
 
   lazy val updates =
     Vector.tabulate(nUpdates)(_ ⇒ Update(r.nextLong.updateId, Some(Message(r.nextLong.messageId, new Date(r.nextLong), fakeChat))))
 
   override def apply[A](fa: RawRequest[A]): Future[A] = fa match {
-    case m@GetMe                   =>
+    case m @ GetMe =>
       Future.successful(Response(ok = true, Some(User(r.nextInt.userId, r.nextString(5)))))
-    case m@SendMessage(payload)    =>
+    case m @ SendMessage(payload) =>
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@ForwardMessage(payload) =>
+    case m @ ForwardMessage(payload) =>
       Future.successful(Response(ok = true, Some(fakeMessage)))
 
-    case m@SendPhoto(payload) ⇒
+    case m @ SendPhoto(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendAudio(payload) ⇒
+    case m @ SendAudio(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendDocument(payload) ⇒
+    case m @ SendDocument(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendSticker(payload) ⇒
+    case m @ SendSticker(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendVideo(payload) ⇒
+    case m @ SendVideo(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendVoice(payload) ⇒
+    case m @ SendVoice(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendLocation(payload) ⇒
+    case m @ SendLocation(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendVenue(payload) ⇒
+    case m @ SendVenue(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendContact(payload) ⇒
+    case m @ SendContact(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeMessage)))
-    case m@SendChatAction(payload) ⇒
+    case m @ SendChatAction(payload) ⇒
       Future.successful(Response(ok = true, Some(true)))
-    case m@GetUserProfilePhotos(payload) ⇒
+    case m @ GetUserProfilePhotos(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeUserProfilePhotos)))
-    case m@GetFile(payload) ⇒
+    case m @ GetFile(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeFile)))
-    case m@KickChatMember(payload) ⇒
+    case m @ KickChatMember(payload) ⇒
       Future.successful(Response(ok = true, Some(true)))
-    case m@LeaveChat(payload) ⇒
+    case m @ LeaveChat(payload) ⇒
       Future.successful(Response(ok = true, Some(true)))
-    case m@UnbanChatMember(payload) ⇒
+    case m @ UnbanChatMember(payload) ⇒
       Future.successful(Response(ok = true, Some(true)))
-    case m@GetChat(payload) ⇒
+    case m @ GetChat(payload) ⇒
       Future.successful(Response(ok = true, Some(fakeChat)))
-    case m@GetChatAdministrators(payload) ⇒
+    case m @ GetChatAdministrators(payload) ⇒
       Future.successful(Response(ok = true, Some(Vector(ChatMember(fakeUser, MemberStatus.Member)))))
-    case m@GetChatMembersCount(payload) ⇒
+    case m @ GetChatMembersCount(payload) ⇒
       Future.successful(Response(ok = true, Some(r.nextInt)))
-    case m@GetChatMember(payload) ⇒
+    case m @ GetChatMember(payload) ⇒
       Future.successful(Response(ok = true, Some(ChatMember(fakeUser, MemberStatus.Member))))
-    case m@AnswerCallbackQuery(payload) ⇒
+    case m @ AnswerCallbackQuery(payload) ⇒
       Future.successful(Response(ok = true, Some(true)))
 
-    case m@GetUpdates(payload)     =>
+    case m @ GetUpdates(payload) =>
       Future.successful(Response(ok = true, Some(updates)))
 
-    case m@EditMessageCaption(payload)     ⇒
+    case m @ EditMessageCaption(payload) ⇒
       Future.successful(Response(ok = true, Some(Right(fakeMessage))))
-    case m@EditMessageReplyMarkup(payload) ⇒
+    case m @ EditMessageReplyMarkup(payload) ⇒
       Future.successful(Response(ok = true, Some(Right(fakeMessage))))
-    case m@EditMessageText(payload)        ⇒
+    case m @ EditMessageText(payload) ⇒
       Future.successful(Response(ok = true, Some(Right(fakeMessage))))
   }
 

--- a/src/main/scala/com/github/nikdon/telepooz/engine/Polling.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/Polling.scala
@@ -19,10 +19,10 @@ import scala.concurrent.duration._
 
 class Polling(implicit apiRequestExecutor: ApiRequestExecutor, ec: ExecutionContextExecutor, logger: LoggingAdapter) {
 
-  private[this] val config     : Config         = ConfigFactory.load()
-  private[this] val interval   : FiniteDuration = config.getInt("telegram.polling.interval").millis
-  private[this] val limit      : Int            = config.getInt("telegram.polling.limit")
-  private[this] val parallelism: Int            = config.getInt("telegram.polling.parallelism")
+  private[this] val config: Config           = ConfigFactory.load()
+  private[this] val interval: FiniteDuration = config.getInt("telegram.polling.interval").millis
+  private[this] val limit: Int               = config.getInt("telegram.polling.limit")
+  private[this] val parallelism: Int         = config.getInt("telegram.polling.parallelism")
 
   val pollGraph: Graph[SourceShape[Update], NotUsed] = GraphDSL.create() { implicit builder ⇒
     import GraphDSL.Implicits._
@@ -40,25 +40,23 @@ class Polling(implicit apiRequestExecutor: ApiRequestExecutor, ec: ExecutionCont
       * with obtained update_id. If collection of [[Update]] is empty, produce a default [[methods.GetUpdates]]
       * entity
       */
-    val C: FlowShape[immutable.Seq[Update], methods.GetUpdates] = builder.add(
-      Flow[immutable.Seq[Update]].map {
-        case Seq()   ⇒
-          logger.debug("Received empty array of Updates")
-          methods.GetUpdates()
-        case updates ⇒
-          logger.debug(s"Received ${updates.length} updates: ${updates.map(_.update_id).mkString(", ")}")
-          val lastUpdate = updates.maxBy(_.update_id.toInt)
-          val akkUpdateId = (lastUpdate.update_id + 1).updateId
-          methods.GetUpdates(Some(akkUpdateId), Some(limit))
-      })
+    val C: FlowShape[immutable.Seq[Update], methods.GetUpdates] = builder.add(Flow[immutable.Seq[Update]].map {
+      case Seq() ⇒
+        logger.debug("Received empty array of Updates")
+        methods.GetUpdates()
+      case updates ⇒
+        logger.debug(s"Received ${updates.length} updates: ${updates.map(_.update_id).mkString(", ")}")
+        val lastUpdate  = updates.maxBy(_.update_id.toInt)
+        val akkUpdateId = (lastUpdate.update_id + 1).updateId
+        methods.GetUpdates(Some(akkUpdateId), Some(limit))
+    })
 
     /** Execute a [[methods.GetUpdates]] via the provided api */
-    val D: FlowShape[methods.GetUpdates, immutable.Seq[Update]] = builder.add(
-      Flow[methods.GetUpdates].mapAsync(parallelism) {
-        case gu: methods.GetUpdates ⇒
-          logger.debug("Executing a GetUpdates request")
-          api.execute(gu.toRawRequest).foldMap(apiRequestExecutor).map(_.result.fold(Vector.empty[Update])(identity))
-      })
+    val D: FlowShape[methods.GetUpdates, immutable.Seq[Update]] = builder.add(Flow[methods.GetUpdates].mapAsync(parallelism) {
+      gu: methods.GetUpdates ⇒
+        logger.debug("Executing a GetUpdates request")
+        api.execute(gu.toRawRequest).foldMap(apiRequestExecutor).map(_.result.fold(Vector.empty[Update])(identity))
+    })
 
     /** Merge two input streams of [[methods.GetUpdates]]. Created because of the initial producer [[A]] */
     val F: UniformFanInShape[methods.GetUpdates, methods.GetUpdates] = builder.add(Merge[methods.GetUpdates](2))
@@ -84,6 +82,6 @@ class Polling(implicit apiRequestExecutor: ApiRequestExecutor, ec: ExecutionCont
                                      E ~> Y
              C           <~          E
 
-      SourceShape(Y.out)
-    }
+    SourceShape(Y.out)
+  }
 }

--- a/src/main/scala/com/github/nikdon/telepooz/engine/Reactor.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/Reactor.scala
@@ -39,7 +39,6 @@ object Reactions {
 
 abstract class Reactor(implicit are: ApiRequestExecutor, ec: ExecutionContext, logger: LoggingAdapter) extends CirceEncoders {
 
-  /** Override as lazy val */
   val reactions: Reactions
 
   private[this] val config     : Config = ConfigFactory.load()

--- a/src/main/scala/com/github/nikdon/telepooz/engine/Telepooz.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/Telepooz.scala
@@ -12,14 +12,12 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 
 trait Telepooz {
 
-  implicit val system: ActorSystem = ActorSystem("AkkaBot")
+  implicit val system: ActorSystem                = ActorSystem("AkkaBot")
   implicit val executor: ExecutionContextExecutor = system.dispatcher
-  implicit val materializer: Materializer = ActorMaterializer()
+  implicit val materializer: Materializer         = ActorMaterializer()
 
   implicit val logger = Logging(system, getClass)
 
-
-  /**  */
   def instance = ReaderT[Future, (ApiRequestExecutor, Polling, Reactor), Done] {
     case (are, poller, reactor) ⇒
       Source.fromGraph(poller.pollGraph).runWith(reactor.react)

--- a/src/main/scala/com/github/nikdon/telepooz/engine/Telepooz.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/engine/Telepooz.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 
 trait Telepooz {
 
-  implicit val system: ActorSystem                = ActorSystem("AkkaBot")
+  implicit val system: ActorSystem                = ActorSystem("Telepooz")
   implicit val executor: ExecutionContextExecutor = system.dispatcher
   implicit val materializer: Materializer         = ActorMaterializer()
 

--- a/src/main/scala/com/github/nikdon/telepooz/tags.scala
+++ b/src/main/scala/com/github/nikdon/telepooz/tags.scala
@@ -9,8 +9,8 @@ trait IsResourceId[A]
 
 
 object IsResourceId {
-  implicit val intIsResourceId = new IsResourceId[Int] {}
-  implicit val longIsResourceId = new IsResourceId[Long] {}
+  implicit val intIsResourceId    = new IsResourceId[Int]    {}
+  implicit val longIsResourceId   = new IsResourceId[Long]   {}
   implicit val stringIsResourceId = new IsResourceId[String] {}
 }
 
@@ -29,14 +29,14 @@ object tags {
   trait Syntax {
 
     implicit class ResiurseIdOps[A: IsResourceId](a: A) {
-      def chatId: A @@ ChatId = tag[ChatId](a)
-      def fileId: A @@ FileId = tag[FileId](a)
+      def chatId: A @@ ChatId             = tag[ChatId](a)
+      def fileId: A @@ FileId             = tag[FileId](a)
       def foursquareId: A @@ FoursquareId = tag[FoursquareId](a)
-      def messageId: A @@ MessageId = tag[MessageId](a)
-      def resultId: A @@ ResultId = tag[ResultId](a)
-      def updateId: A @@ UpdateId = tag[UpdateId](a)
-      def userId: A @@ UserId = tag[UserId](a)
-      def queryId: A @@ QueryId = tag[QueryId](a)
+      def messageId: A @@ MessageId       = tag[MessageId](a)
+      def resultId: A @@ ResultId         = tag[ResultId](a)
+      def updateId: A @@ UpdateId         = tag[UpdateId](a)
+      def userId: A @@ UserId             = tag[UserId](a)
+      def queryId: A @@ QueryId           = tag[QueryId](a)
     }
 
   }

--- a/src/test/scala/com/github/nikdon/telepooz/engine/PollingTest.scala
+++ b/src/test/scala/com/github/nikdon/telepooz/engine/PollingTest.scala
@@ -1,0 +1,48 @@
+package com.github.nikdon.telepooz.engine
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.{ActorMaterializer, Materializer}
+import com.github.nikdon.telepooz.model.Update
+import org.scalatest.concurrent.{ScalaFutures, ScaledTimeSpans}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContextExecutor
+
+
+class PollingTest
+    extends FlatSpec
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with ScalaFutures
+    with BeforeAndAfterAll
+    with ScaledTimeSpans {
+
+  override def spanScaleFactor: Double = 10.0
+
+  implicit val system: ActorSystem                = ActorSystem("PollingTestSystem")
+  implicit val executor: ExecutionContextExecutor = system.dispatcher
+  implicit val materializer: Materializer         = ActorMaterializer()
+  implicit val logger                             = Logging(system, getClass)
+  implicit val are                                = new ApiRequestExecutor() {}
+
+  behavior of "Polling"
+
+  it should "emit updates" in {
+    val n            = 5
+    implicit val are = new MockApiRequestExecutor(nUpdates = n)
+    val poller       = new Polling
+    val f            = Source.fromGraph(poller.pollGraph).take(n.toLong).runWith(Sink.seq)
+
+    whenReady(f) { res ⇒
+      res.size shouldBe 5
+      res.foreach(u ⇒ u shouldBe an[Update])
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    system.terminate()
+  }
+}

--- a/src/test/scala/com/github/nikdon/telepooz/engine/PollingTest.scala
+++ b/src/test/scala/com/github/nikdon/telepooz/engine/PollingTest.scala
@@ -20,7 +20,7 @@ class PollingTest
     with BeforeAndAfterAll
     with ScaledTimeSpans {
 
-  override def spanScaleFactor: Double = 10.0
+  override def spanScaleFactor: Double = 20.0
 
   implicit val system: ActorSystem                = ActorSystem("PollingTestSystem")
   implicit val executor: ExecutionContextExecutor = system.dispatcher

--- a/src/test/scala/com/github/nikdon/telepooz/engine/ReactorTest.scala
+++ b/src/test/scala/com/github/nikdon/telepooz/engine/ReactorTest.scala
@@ -100,7 +100,6 @@ class ReactorTest
     val probe = TestProbe()
 
     val triggeringReactor = new Reactor() {
-
       val reactions = Reactions().on("/test")(implicit message ⇒ args ⇒ Future.successful("test") pipeTo probe.ref)
     }
 

--- a/src/test/scala/com/github/nikdon/telepooz/examples/NaiveBot.scala
+++ b/src/test/scala/com/github/nikdon/telepooz/examples/NaiveBot.scala
@@ -1,20 +1,17 @@
 package com.github.nikdon.telepooz.examples
 
-import com.github.nikdon.telepooz.engine.{ApiRequestExecutor, Polling, Reactor, Telepooz}
+import com.github.nikdon.telepooz.engine.{ApiRequestExecutor, Polling, Reactions, Reactor, Telepooz}
 
 
 /** Just an example of how the bot might look like */
 object NaiveBot extends Telepooz with App {
 
   implicit val are = new ApiRequestExecutor {}
-  val poller  = new Polling
-  val reactor = new Reactor {
-
-    /** Initialize as lazy val */
-    lazy val reactions: Map[String, Reaction] = Map(
-      "/start" → (implicit message ⇒ args ⇒ reply("You are started!")),
-      "/test" → (implicit message ⇒ args ⇒ reply("Hi there!"))
-    )
+  val poller       = new Polling
+  val reactor      = new Reactor {
+    val reactions = Reactions()
+      .on("/start")(implicit message ⇒ args ⇒ reply("You are started!"))
+      .on("/test")(implicit message ⇒ args ⇒ reply("Hi there!"))
   }
 
   instance.run((are, poller, reactor))

--- a/src/test/scala/com/github/nikdon/telepooz/examples/SelfBot.scala
+++ b/src/test/scala/com/github/nikdon/telepooz/examples/SelfBot.scala
@@ -1,16 +1,20 @@
 package com.github.nikdon.telepooz.examples
 
-import com.github.nikdon.telepooz.engine.{MockApiRequestExecutor, Polling, Reactor, Telepooz}
-
+import com.github.nikdon.telepooz.engine.{
+  MockApiRequestExecutor,
+  Polling,
+  Reactions,
+  Reactor,
+  Telepooz
+}
 
 /** This bot produce 1000 messages every tick and try to respond on them */
 object SelfBot extends Telepooz with App {
 
   implicit val are = new MockApiRequestExecutor(1000)
-  val poller  = new Polling
-  val reactor = new Reactor {
-    /** Initialize as lazy val */
-    lazy val reactions: Map[String, Reaction] = Map()
+  val poller       = new Polling
+  val reactor      = new Reactor {
+    val reactions = Reactions()
   }
 
   instance.run((are, poller, reactor))


### PR DESCRIPTION
Replace `Map[String, ...]` by `Reactions` as a container for IO ops.

Now it's possible to create reactions inside `Reactor` as follows: 

``` scala
val reactions = Reactions()
      .on("/start")(implicit message ⇒ args ⇒ reply("You are started!"))
      .on("/test")(implicit message ⇒ args ⇒ reply("Hi there!"))
```
